### PR TITLE
🔨 chore: refactor MangaList model import and remove duplicate code

### DIFF
--- a/app/functions/class_mangalist.py
+++ b/app/functions/class_mangalist.py
@@ -1,0 +1,38 @@
+from sqlalchemy import  Column, Integer, String, Float, TIMESTAMP, Text, Boolean
+from sqlalchemy.orm import declarative_base
+Base = declarative_base()
+
+
+class MangaList(Base):
+    __tablename__ = 'manga_list'
+    id_default = Column(Integer, primary_key=True, autoincrement=True)
+    id_anilist = Column(Integer, nullable=False)
+    id_mal = Column(Integer)
+    title_english = Column(String(255))
+    title_romaji = Column(String(255))
+    on_list_status = Column(String(255))
+    status = Column(String(255))
+    media_format = Column(String(255))
+    all_chapters = Column(Integer, default=0)
+    all_volumes = Column(Integer, default=0)
+    chapters_progress = Column(Integer, default=0)
+    volumes_progress = Column(Integer, default=0)
+    score = Column(Float, default=0)
+    reread_times = Column(Integer, default=0)
+    cover_image = Column(String(255))
+    is_cover_downloaded = Column(Boolean, default=False)
+    is_favourite = Column(Integer, default=0)
+    anilist_url = Column(String(255))
+    mal_url = Column(String(255))
+    last_updated_on_site = Column(TIMESTAMP)
+    entry_createdAt = Column(TIMESTAMP)
+    user_startedAt = Column(Text, default='not started')
+    user_completedAt = Column(Text, default='not completed')
+    notes = Column(Text)
+    description = Column(Text)
+    country_of_origin = Column(String(255))
+    media_start_date = Column(Text, default='media not started')
+    media_end_date = Column(Text, default='media not ended')
+    genres = Column(Text, default='none genres provided')
+    external_links = Column(Text, default='none links associated')
+    bato_link = Column(Text, default='')

--- a/app/functions/sqlalchemy_fns.py
+++ b/app/functions/sqlalchemy_fns.py
@@ -1,50 +1,12 @@
 from datetime import datetime
 from app import config
-from sqlalchemy import create_engine, Column, Integer, String, DateTime, Float, TIMESTAMP, Text, exc,  Boolean
+from sqlalchemy import create_engine, exc
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql import func
-# from config import Config  # This import might not be needed for SQLite configuration
+from app.functions import class_mangalist
 
 Base = declarative_base()
-
-class MangaList(Base):
-    __tablename__ = 'manga_list'
-    id_default = Column(Integer, primary_key=True, autoincrement=True)
-    id_anilist = Column(Integer, nullable=False)
-    id_mal = Column(Integer)
-    title_english = Column(String(255))
-    title_romaji = Column(String(255))
-    on_list_status = Column(String(255))
-    status = Column(String(255))
-    media_format = Column(String(255))
-    all_chapters = Column(Integer, default=0)
-    all_volumes = Column(Integer, default=0)
-    chapters_progress = Column(Integer, default=0)
-    volumes_progress = Column(Integer, default=0)
-    score = Column(Float, default=0)
-    reread_times = Column(Integer, default=0)
-    cover_image = Column(String(255))
-    is_cover_downloaded = Column(Boolean, default=False)
-    is_favourite = Column(Integer, default=0)
-    anilist_url = Column(String(255))
-    mal_url = Column(String(255))
-    last_updated_on_site = Column(TIMESTAMP)
-    entry_createdAt = Column(TIMESTAMP)
-    user_startedAt = Column(Text, default='not started')
-    user_completedAt = Column(Text, default='not completed')
-    notes = Column(Text)
-    description = Column(Text)
-    country_of_origin = Column(String(255))
-    media_start_date = Column(Text, default='media not started')
-    media_end_date = Column(Text, default='media not ended')
-    genres = Column(Text, default='none genres provided')
-    external_links = Column(Text, default='none links associated')
-    bato_link = Column(Text, default='')  # Adjust types and column names as necessary
-
-
-
-
+MangaList = class_mangalist.MangaList
   
 def get_engine():
     return create_engine(config.DATABASE_URI)

--- a/app/functions/sqlalchemy_fns_mariadb.py
+++ b/app/functions/sqlalchemy_fns_mariadb.py
@@ -1,46 +1,13 @@
 from datetime import datetime
-from sqlalchemy import create_engine, Column, Integer, String, DateTime, Float, TIMESTAMP, Text, exc, Boolean
+from sqlalchemy import create_engine, exc
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql import func
 from config import Config
-
+from app.functions import class_mangalist
 
 Base = declarative_base()
+MangaList = class_mangalist.MangaList
 
-class MangaList(Base):
-    __tablename__ = 'manga_list'
-    id_default = Column(Integer, primary_key=True, autoincrement=True)
-    id_anilist = Column(Integer, nullable=False)
-    id_mal = Column(Integer)
-    title_english = Column(String(255))
-    title_romaji = Column(String(255))
-    on_list_status = Column(String(255))
-    status = Column(String(255))
-    media_format = Column(String(255))
-    all_chapters = Column(Integer, default=0)
-    all_volumes = Column(Integer, default=0)
-    chapters_progress = Column(Integer, default=0)
-    volumes_progress = Column(Integer, default=0)
-    score = Column(Float, default=0)
-    reread_times = Column(Integer, default=0)
-    cover_image = Column(String(255))
-    is_cover_downloaded = Column(Boolean, default=False)
-    is_favourite = Column(Integer, default=0)
-    anilist_url = Column(String(255))
-    mal_url = Column(String(255))
-    last_updated_on_site = Column(TIMESTAMP)
-    entry_createdAt = Column(TIMESTAMP)
-    user_startedAt = Column(Text, default='not started')
-    user_completedAt = Column(Text, default='not completed')
-    notes = Column(Text)
-    description = Column(Text)
-    country_of_origin = Column(String(255))
-    media_start_date = Column(Text, default='media not started')
-    media_end_date = Column(Text, default='media not ended')
-    genres = Column(Text, default='none genres provided')
-    external_links = Column(Text, default='none links associated')
-    bato_link = Column(Text, default='')  # Adjust types and column names as necessary
 
 
 def get_manga_list_alchemy(config, testing=False):

--- a/app/tests/test_sqlalchemy_fns.py
+++ b/app/tests/test_sqlalchemy_fns.py
@@ -1,46 +1,10 @@
 from unittest import mock
 from app.functions.sqlalchemy_fns import get_manga_list_alchemy
-from sqlalchemy import Column, Integer, String, Float, TIMESTAMP, Text, Boolean
-
 from sqlalchemy.orm import declarative_base
-
-
+from app.functions.class_mangalist import MangaList as MockManga
 
 Base = declarative_base()
 
-class MockManga(Base):
-    __tablename__ = 'manga_list'
-    id_default = Column(Integer, primary_key=True, autoincrement=True)
-    id_anilist = Column(Integer, nullable=False)
-    id_mal = Column(Integer)
-    title_english = Column(String(255))
-    title_romaji = Column(String(255))
-    on_list_status = Column(String(255))
-    status = Column(String(255))
-    media_format = Column(String(255))
-    all_chapters = Column(Integer, default=0)
-    all_volumes = Column(Integer, default=0)
-    chapters_progress = Column(Integer, default=0)
-    volumes_progress = Column(Integer, default=0)
-    score = Column(Float, default=0)
-    reread_times = Column(Integer, default=0)
-    cover_image = Column(String(255))
-    is_cover_downloaded = Column(Boolean, default=False)
-    is_favourite = Column(Integer, default=0)
-    anilist_url = Column(String(255))
-    mal_url = Column(String(255))
-    last_updated_on_site = Column(TIMESTAMP)
-    entry_createdAt = Column(TIMESTAMP)
-    user_startedAt = Column(Text, default='not started')
-    user_completedAt = Column(Text, default='not completed')
-    notes = Column(Text)
-    description = Column(Text)
-    country_of_origin = Column(String(255))
-    media_start_date = Column(Text, default='media not started')
-    media_end_date = Column(Text, default='media not ended')
-    genres = Column(Text, default='none genres provided')
-    external_links = Column(Text, default='none links associated')
-    bato_link = Column(Text, default='')  # Adjust types and column names as necessary
 
 @mock.patch('app.functions.sqlalchemy_fns.get_session')
 def test_get_manga_list_alchemy_mock(mock_get_session):


### PR DESCRIPTION
The import statement for the MangaList model has been refactored to import it from the `app.functions.class_mangalist` module. This helps to improve code organization and avoid duplicate code.