### PR TITLE
feat: Add Content Security Policy and cover download functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,9 @@
         ".",
         "-p",
         "test_*.py"
-    ]
+    ],
+    "sonarlint.connectedMode.project": {
+        "connectionId": "shiroepl",
+        "projectKey": "ShiroePL_EasternTalesShelf"
+    }
 }

--- a/app/database_module/docker-compose.yml
+++ b/app/database_module/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - /dev/net/tun
     environment:
       - OAUTH_CLIENT_SECRET
-      - VAULT_ADDR
+      - VAULT_ADDR=${VAULT_ADDR_tailscale}
       - VAULT_ROLE_ID_shiro_chan_project
       - VAULT_SECRET_ID_shiro_chan_project
       - FLASK_ENV


### PR DESCRIPTION
Add Content Security Policy to set security headers in the response.
Update the response header 'Content-Security-Policy' with specific policies.
Identify and download missing covers for manga entries.
Update the database for successful cover downloads.
Fix my ip for vault variables