### PR TITLE
Add scraping functionality for Batoto links

### DIFF
--- a/app/functions/sqlalchemy_fns.py
+++ b/app/functions/sqlalchemy_fns.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import json
 from sqlalchemy import exc
 from app.functions.class_mangalist import engine, Base, MangaList, db_session, session_maker
 from app.config import is_development_mode # development or production
@@ -41,19 +42,30 @@ def update_cover_download_status_bulk(ids_to_download, status):
     finally:
         db_session.remove()
 
-def add_bato_link(id_anilist, bato_link):
-    """Add a 'bato' link to a manga entry."""
+def update_manga_links(id_anilist, bato_link, extracted_links):
+    """Update manga entry with Bato and MangaUpdates links."""
     with session_maker() as session:
         try:
             manga_entry = session.query(MangaList).filter_by(id_anilist=id_anilist).first()
             if manga_entry:
                 manga_entry.bato_link = bato_link
+
+                # Convert existing links to a list if stored as a string
+                existing_links = eval(manga_entry.external_links) if manga_entry.external_links else []
+
+                # Add MangaUpdates link if it's not already in the existing links
+                new_links = [link for link in extracted_links if link not in existing_links]
+                updated_links = existing_links + new_links
+
+                # Ensure links are stored with double quotes
+                manga_entry.external_links = json.dumps(updated_links)  # This will store list with double quotes
+
                 session.commit()
             else:
                 print("Manga entry not found for AniList ID:", id_anilist)
         except exc.SQLAlchemyError as e:
             session.rollback()
-            print("Error updating 'bato_link':", e)
+            print("Error updating manga links:", e)
         finally:
             session.remove()
 

--- a/app/static/scripts.js
+++ b/app/static/scripts.js
@@ -578,6 +578,7 @@ function showDetails(element) {
         // ---------------------------OPERATION ON LINK BUTTONS--------------------
 
         let serviceMap = {
+            'mangaupdates.com': { name: 'MangaUpdates', class: 'sevenseas' },
             'tapas.io': { name: 'Tapas', class: 'tapas' },
             'tappytoon.com': { name: 'Tappytoon', class: 'tappytoon' },
             'www.webtoons.com': { name: 'Webtoons', class: 'webtoons' },
@@ -586,10 +587,24 @@ function showDetails(element) {
             'j-novel.club': { name: 'J-Novel Club', class: 'jnovel' },
             // Add more mappings as needed
         };
-
+        
+        // Assign order based on the position in the object
+        Object.keys(serviceMap).forEach((key, index) => {
+            serviceMap[key].order = index + 1;
+        });
+        
         // Safely parse the JSON string into an array for external links
         try {
             let externalLinks = JSON.parse(externalLinksData || "[]");
+        
+            // Function to find the order of a URL based on serviceMap
+            function findOrder(url) {
+                return Object.keys(serviceMap).find(key => url.includes(key)) ? serviceMap[key].order : Number.MAX_VALUE;
+            }
+        
+            // Sort links based on the dynamically assigned order in serviceMap
+            externalLinks.sort((a, b) => findOrder(a) - findOrder(b));
+        
             let linksContainer = document.getElementById('sidebar-external-links');
         
             if (externalLinks.length === 0) {
@@ -602,7 +617,7 @@ function showDetails(element) {
                     Object.keys(serviceMap).forEach(function(key) {
                         if (url.includes(key)) {
                             let serviceName = serviceMap[key].name;
-                            let linkClass = serviceMap[key].class; // Custom class for serviceMap links
+                            let linkClass = serviceMap[key].class;
                             let button = document.createElement('a');
                             button.href = url;
                             button.textContent = serviceName;
@@ -623,6 +638,7 @@ function showDetails(element) {
             console.error('Parsing error for external-links data:', e);
             document.getElementById('sidebar-external-links').innerHTML = '<h5 class="mb-2">No links available</h5>';
         }
+        
         
 
         // ------------------------------- end of link buttons ---------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 annotated-types==0.6.0
 anyio==4.2.0
+beautifulsoup4==4.12.3
 blinker==1.7.0
 certifi==2023.11.17
 charset-normalizer==3.3.2
@@ -29,6 +30,7 @@ pydantic_core==2.16.1
 PyMySQL==1.1.0
 requests==2.31.0
 sniffio==1.3.0
+soupsieve==2.5
 SQLAlchemy==2.0.25
 tqdm==4.66.1
 typing_extensions==4.9.0


### PR DESCRIPTION
This pull request adds functionality to scrape the Batoto page when adding a Batoto link to a manga entry. The scraped data includes links from the Astro Islands section of the page, which are then cleaned, decoded, and filtered before being stored in the database.