### PR TITLE
✨ perf(grid): hide download controls for offscreen items

### DIFF
--- a/.github/workflows/container_building.yml
+++ b/.github/workflows/container_building.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'requirements.txt'
       - 'Dockerfile'
+      - 'app/**'  # Dodaj to żeby rebuildować gdy zmienia się kod!
 
 jobs:
   build-and-push:
@@ -29,19 +30,25 @@ jobs:
       - name: Lowercase repository name
         run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
         
-      - name: Build and Tag for Both Local and GitHub Registry
+      - name: Build and push with buildx
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64  # Explicit dla twojego ARM VPS
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO_LC }}:latest
+            ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          
+      - name: Tag for local use
         run: |
-          echo "Checking out the branch that triggered the workflow..."
-          git checkout ${{ github.ref_name }}  # Switch to the correct branch
-
-          echo "Building image for both local use and GitHub Container Registry..."
-          # Build the image with local tag
-          docker build -t easterntalesshelf:local .
+          # Pull i retag dla local Docker daemon
+          docker pull ghcr.io/${{ env.REPO_LC }}:latest
+          docker tag ghcr.io/${{ env.REPO_LC }}:latest easterntalesshelf:local
           
-          # Tag the same image for GitHub Container Registry 
-          docker tag easterntalesshelf:local ghcr.io/${{ env.REPO_LC }}:latest
-          docker tag easterntalesshelf:local ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}
-          
-          # Push to GitHub Container Registry
-          docker push ghcr.io/${{ env.REPO_LC }}:latest
-          docker push ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/app/static/css/components/grid-item.css
+++ b/app/static/css/components/grid-item.css
@@ -225,6 +225,11 @@
     z-index: 99998;
 }
 
+/* Hide controls when grid item is not visible for performance */
+.grid-item:not(.is-visible) .manga-controls {
+    display: none;
+}
+
 .download-status-btn {
     background-color: #000000; /* Solid black background instead of transparent */
     border: 2px solid var(--border-color);
@@ -264,7 +269,7 @@
 
 .download-status-btn[data-status="pending"] {
     color: #ffc107;  /* Yellow */
-    animation: pulse 2s infinite;
+    /* animation: pulse 2s infinite; */ /* DISABLED FOR PERFORMANCE */
     opacity: 1;
 }
 
@@ -281,7 +286,7 @@
     opacity: 1;
     box-shadow: 0 0 12px rgba(255, 215, 0, 0.6); /* Golden glow */
     color:#4db8ff;
-    animation: pulse 2s ease-in-out infinite; /* Added ease-in-out for smoother transition */
+    /* animation: pulse 2s ease-in-out infinite; */ /* DISABLED FOR PERFORMANCE */
     position: relative;
     z-index: 100000; /* Higher z-index to ensure it's on top */
 }
@@ -297,7 +302,7 @@
     background-size: 300% 300%;
     border-radius: 50%;
     z-index: -1;
-    animation: gradient-shift 6s ease infinite;
+    /* animation: gradient-shift 6s ease infinite; */ /* DISABLED FOR PERFORMANCE */
 }
 
 /* Special styling for the star icon */
@@ -307,7 +312,7 @@
     background-size: 300% 300%;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent; /* Keep only the webkit version */
-    animation: gradient-shift 6s ease infinite; /* Only color shift for the icon */
+    /* animation: gradient-shift 6s ease infinite; */ /* DISABLED FOR PERFORMANCE */
 }
 
 /* Gradient color shifting animation */
@@ -372,7 +377,7 @@
 
 .download-status-btn[data-status="queued"] {
     color: #6f42c1;  /* Purple */
-    animation: pulse 2s infinite;
+    /* animation: pulse 2s infinite; */ /* DISABLED FOR PERFORMANCE */
     opacity: 1;
 }
 

--- a/app/static/js/downloadButtonVisibility.js
+++ b/app/static/js/downloadButtonVisibility.js
@@ -1,0 +1,52 @@
+// Performance optimization: Only show download buttons for visible grid items
+// This reduces the number of DOM elements the browser needs to render
+
+let visibilityObserver = null;
+
+function initializeDownloadButtonVisibility() {
+    // Clean up existing observer if any
+    if (visibilityObserver) {
+        visibilityObserver.disconnect();
+    }
+
+    // Create intersection observer with a margin to preload items slightly before they're visible
+    visibilityObserver = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                // Item is visible or about to be visible
+                entry.target.classList.add('is-visible');
+            } else {
+                // Item is off-screen
+                entry.target.classList.remove('is-visible');
+            }
+        });
+    }, {
+        // Start showing buttons 200px before they enter viewport
+        rootMargin: '200px',
+        // Trigger when at least 1% of the item is visible
+        threshold: 0.01
+    });
+
+    // Observe all grid items
+    const gridItems = document.querySelectorAll('.grid-item');
+    gridItems.forEach(item => {
+        visibilityObserver.observe(item);
+    });
+
+    console.log(`Observing ${gridItems.length} grid items for download button visibility`);
+}
+
+// Initialize when manga grid is loaded
+document.addEventListener('mangaGridLoaded', () => {
+    console.log('Initializing download button visibility optimization');
+    initializeDownloadButtonVisibility();
+});
+
+// Also initialize on page load as fallback
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        setTimeout(initializeDownloadButtonVisibility, 1000);
+    });
+} else {
+    setTimeout(initializeDownloadButtonVisibility, 1000);
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -88,6 +88,7 @@
     <script src="{{ url_for('static', filename='js/aos_stuff.js') }}"></script>
     <script src="{{ url_for('static', filename='js/filters.js') }}"></script>
     <script src="{{ url_for('static', filename='js/eventListeners.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/downloadButtonVisibility.js') }}"></script>
     
     <!-- Page-specific scripts -->
     {% block scripts %}{% endblock %}

--- a/app/templates/sections/_manga_grid.html
+++ b/app/templates/sections/_manga_grid.html
@@ -1,14 +1,18 @@
 <!-- Dynamic manga grid container -->
-<div id="manga-grid-container" 
-     data-is-admin="{{ current_user.is_admin }}" 
-     data-is-development="{{ isDevelopment }}">
-    <!-- Loading placeholder -->
-    <div class="loading-container">
-        <div class="loading-spinner"></div>
-        <p>Loading manga collection...</p>
-    </div>
+<div
+  id="manga-grid-container"
+  data-is-admin="{{ current_user.is_admin }}"
+  data-is-development="{{ isDevelopment }}"
+>
+  <!-- Loading placeholder -->
+  <div class="loading-container">
+    <div class="loading-spinner"></div>
+    <p>Loading manga collection...</p>
+  </div>
 </div>
 
 <!-- Include the MangaGridLoader script -->
-<script type="module" src="{{ url_for('static', filename='js/MangaGridLoader.js') }}"></script>
-
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/MangaGridLoader.js') }}"
+></script>


### PR DESCRIPTION
Hide download controls and disable heavy animations for offscreen grid items to reduce render work and improve scrolling performance.

- Add IntersectionObserver-based downloadButtonVisibility.js that toggles .is-visible on .grid-item elements and initializes when the manga grid finishes loading. Observes with a 200px rootMargin and 0.01 threshold.
- Include the new script in base.html so the observer runs on page load.
- Hide .manga-controls for .grid-item:not(.is-visible) in CSS so controls are not rendered when items are offscreen.
- Comment-out multiple animation declarations (pulse, gradient-shift) on download status buttons and icons to prevent continuous repaints and layout churn.

These changes reduce DOM rendering and animation overhead to improve scrolling and overall UI responsiveness.

## Summary by Sourcery

Lazily show download controls via IntersectionObserver and hide offscreen controls to reduce render work, disable heavy animations for smoother scrolling, and modernize the CI pipeline with multi-platform Docker build and caching.

New Features:
- Add a downloadButtonVisibility script that observes grid items and toggles visibility of download controls based on scroll position

Enhancements:
- Hide manga controls via CSS on grid items that are not visible
- Disable pulse and gradient-shift animations on download status buttons and icons to reduce repaint overhead

CI:
- Update GitHub Actions workflow to use docker/build-push-action@v5 with buildx multi-platform builds, caching, local tagging, and rebuild on code changes